### PR TITLE
Refactor assets service

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Hiram Torres Lopez
+Copyright (c) 2025 Hiram
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ go build -ldflags="-X 'main.version=v0.7.0' -X 'main.commit=$(git rev-parse --sh
 
 ## License
 
-Licensed under [MIT License](LICENSE). © 2024 Hiram Torres Lopez.
+Licensed under [MIT License](LICENSE). © 2025 Hiram Torres Lopez.

--- a/mongodb/videos.go
+++ b/mongodb/videos.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -50,11 +49,7 @@ func (db *DB) Create(ctx context.Context, anyVideo model.Video) (model.Video, er
 
 	_, err := collection.InsertOne(ctx, insert)
 	if err != nil {
-		db.logger.WithFields(logrus.Fields{
-			"step": "collection.InsertOne",
-			"func": "func (v *videos) Insert",
-			"id":   id,
-		}).Error(err.Error())
+		db.logger.WithError(err).Error("error inserting video into collection")
 
 		return model.Video{}, err
 	}
@@ -73,11 +68,7 @@ func (db *DB) GetByID(ctx context.Context, id string) (model.Video, error) {
 	err := collection.FindOne(ctx, filter).Decode(&response)
 
 	if err != nil {
-		db.logger.WithFields(logrus.Fields{
-			"step": "collection.FindOne",
-			"func": "func (v *videos) GetByID",
-			"id":   id,
-		}).Error(err.Error())
+		db.logger.WithError(err).Error("error getting video by ID")
 
 		if err == mongo.ErrNoDocuments {
 			return model.Video{}, errorcodes.ErrVideoNotFound
@@ -103,10 +94,8 @@ func (db *DB) List(ctx context.Context, page, limit int) ([]model.Video, error) 
 	opts := options.Find().SetSkip(skip).SetLimit(lim).SetSort(bson.D{{Key: "createdAt", Value: 1}})
 	cur, err := collection.Find(ctx, bson.D{}, opts)
 	if err != nil {
-		db.logger.WithFields(logrus.Fields{
-			"step": "collection.Find",
-			"func": "func (db *DB) List",
-		}).Error(err.Error())
+		db.logger.WithError(err).Error("error listing videos")
+
 		return nil, err
 	}
 	defer cur.Close(ctx)

--- a/muxinc/assets.go
+++ b/muxinc/assets.go
@@ -8,9 +8,17 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	muxgo "github.com/muxinc/mux-go/v5"
-	"github.com/sirupsen/logrus"
 
 	"github.com/javiertlopez/idlemux/model"
+)
+
+// Constants for image dimensions
+const (
+	posterWidth     = 1920
+	posterHeight    = 1080
+	thumbnailWidth  = 640
+	thumbnailHeight = 360
+	imageTime       = "7"
 )
 
 // asset struct
@@ -20,7 +28,7 @@ type asset struct {
 
 // Ingest send a source file url to mux.com
 // Returns a string Asset ID
-func (a *Assets) Create(ctx context.Context, source string, public bool) (model.Asset, error) {
+func (a *assets) Create(ctx context.Context, source string, public bool) (model.Asset, error) {
 	var policy []muxgo.PlaybackPolicy
 
 	if public {
@@ -40,11 +48,7 @@ func (a *Assets) Create(ctx context.Context, source string, public bool) (model.
 	})
 
 	if err != nil {
-		a.logger.WithFields(logrus.Fields{
-			"step":   "AssetsApi.CreateAsset",
-			"func":   "Create",
-			"source": source,
-		}).Error(err.Error())
+		a.logger.WithError(err).Error("error creating asset")
 
 		return model.Asset{}, err
 	}
@@ -55,10 +59,11 @@ func (a *Assets) Create(ctx context.Context, source string, public bool) (model.
 }
 
 // GetByID retrieves an asset from Mux.com by Asset ID
-func (a *Assets) GetByID(ctx context.Context, id string) (model.Asset, error) {
+func (a *assets) GetByID(ctx context.Context, id string) (model.Asset, error) {
 	response, err := a.mux.AssetsApi.GetAsset(id)
-
 	if err != nil {
+		a.logger.WithError(err).Error("error retrieving asset by ID")
+
 		return model.Asset{}, err
 	}
 
@@ -69,77 +74,111 @@ func (a *Assets) GetByID(ctx context.Context, id string) (model.Asset, error) {
 	asset := body.toModel()
 
 	if len(body.data.PlaybackIds) > 0 {
-		var source, poster, thumbnail string
 		playbackID := body.data.PlaybackIds[0].Id
+		policy := body.data.PlaybackIds[0].Policy
 
-		switch body.data.PlaybackIds[0].Policy {
-		case muxgo.PUBLIC:
-			source = fmt.Sprintf(
-				"https://stream.mux.com/%s.m3u8",
-				playbackID,
-			)
+		if err := a.enrichAssetWithURLs(playbackID, policy, asset.Duration, &asset); err != nil {
+			a.logger.WithError(err).Error("error generating asset URLs")
 
-			poster = fmt.Sprintf(
-				"https://image.mux.com/%s/thumbnail.png?width=%s&height=%s&smart_crop=true&time=%s",
-				playbackID,
-				"1920",
-				"1080",
-				"7",
-			)
-
-			thumbnail = fmt.Sprintf(
-				"https://image.mux.com/%s/thumbnail.png?width=%s&height=%s&smart_crop=true&time=%s",
-				playbackID,
-				"640",
-				"360",
-				"7",
-			)
-		case muxgo.SIGNED:
-			token, err := a.signURL(playbackID, "v", asset.Duration, 0, 0)
-			if err != nil {
-				return model.Asset{}, err
-			}
-
-			source = fmt.Sprintf(
-				"https://stream.mux.com/%s.m3u8?token=%s",
-				playbackID,
-				token,
-			)
-
-			token, err = a.signURL(playbackID, "t", asset.Duration, 1920, 1080)
-			if err != nil {
-				return model.Asset{}, err
-			}
-
-			poster = fmt.Sprintf(
-				"https://image.mux.com/%s/thumbnail.png?token=%s",
-				playbackID,
-				token,
-			)
-
-			token, err = a.signURL(playbackID, "t", asset.Duration, 640, 360)
-			if err != nil {
-				return model.Asset{}, err
-			}
-
-			thumbnail = fmt.Sprintf(
-				"https://image.mux.com/%s/thumbnail.png?token=%s",
-				playbackID,
-				token,
-			)
-		}
-
-		asset.Poster = poster
-		asset.Thumbnail = thumbnail
-		asset.Sources = []model.Source{
-			{
-				Source: source,
-				Type:   "application/x-mpegURL",
-			},
+			return model.Asset{}, err
 		}
 	}
 
 	return asset, nil
+}
+
+// enrichAssetWithURLs adds source, poster, and thumbnail URLs to the asset
+func (a *assets) enrichAssetWithURLs(playbackID string, policy muxgo.PlaybackPolicy, duration float64, asset *model.Asset) error {
+	var source, poster, thumbnail string
+	var err error
+
+	switch policy {
+	case muxgo.PUBLIC:
+		source, poster, thumbnail = a.generatePublicURLs(playbackID)
+	case muxgo.SIGNED:
+		source, poster, thumbnail, err = a.generateSignedURLs(playbackID, duration)
+		if err != nil {
+			return err
+		}
+	}
+
+	asset.Poster = poster
+	asset.Thumbnail = thumbnail
+	asset.Sources = []model.Source{
+		{
+			Source: source,
+			Type:   "application/x-mpegURL",
+		},
+	}
+
+	return nil
+}
+
+// generatePublicURLs creates public URLs for the asset
+func (a *assets) generatePublicURLs(playbackID string) (source, poster, thumbnail string) {
+	source = fmt.Sprintf(
+		"https://stream.mux.com/%s.m3u8",
+		playbackID,
+	)
+
+	poster = fmt.Sprintf(
+		"https://image.mux.com/%s/thumbnail.png?width=%d&height=%d&smart_crop=true&time=%s",
+		playbackID,
+		posterWidth,
+		posterHeight,
+		imageTime,
+	)
+
+	thumbnail = fmt.Sprintf(
+		"https://image.mux.com/%s/thumbnail.png?width=%d&height=%d&smart_crop=true&time=%s",
+		playbackID,
+		thumbnailWidth,
+		thumbnailHeight,
+		imageTime,
+	)
+
+	return source, poster, thumbnail
+}
+
+// generateSignedURLs creates signed URLs for the asset
+func (a *assets) generateSignedURLs(playbackID string, duration float64) (source, poster, thumbnail string, err error) {
+	// Generate video token
+	videoToken, err := a.signURL(playbackID, "v", duration, 0, 0)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error signing URL for video playback: %w", err)
+	}
+
+	// Generate poster token
+	posterToken, err := a.signURL(playbackID, "t", duration, posterWidth, posterHeight)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error signing URL for poster: %w", err)
+	}
+
+	// Generate thumbnail token
+	thumbnailToken, err := a.signURL(playbackID, "t", duration, thumbnailWidth, thumbnailHeight)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error signing URL for thumbnail: %w", err)
+	}
+
+	source = fmt.Sprintf(
+		"https://stream.mux.com/%s.m3u8?token=%s",
+		playbackID,
+		videoToken,
+	)
+
+	poster = fmt.Sprintf(
+		"https://image.mux.com/%s/thumbnail.png?token=%s",
+		playbackID,
+		posterToken,
+	)
+
+	thumbnail = fmt.Sprintf(
+		"https://image.mux.com/%s/thumbnail.png?token=%s",
+		playbackID,
+		thumbnailToken,
+	)
+
+	return source, poster, thumbnail, nil
 }
 
 func (a *asset) toModel() model.Asset {
@@ -155,7 +194,7 @@ func (a *asset) toModel() model.Asset {
 	}
 }
 
-func (a *Assets) signURL(
+func (a *assets) signURL(
 	playbackID string,
 	audience string,
 	duration float64,

--- a/muxinc/assets.go
+++ b/muxinc/assets.go
@@ -77,7 +77,7 @@ func (a *assets) GetByID(ctx context.Context, id string) (model.Asset, error) {
 		playbackID := body.data.PlaybackIds[0].Id
 		policy := body.data.PlaybackIds[0].Policy
 
-		if err := a.enrichAssetWithURLs(playbackID, policy, asset.Duration, &asset); err != nil {
+		if err := a.hydrateAssetURLs(playbackID, policy, asset.Duration, &asset); err != nil {
 			a.logger.WithError(err).Error("error generating asset URLs")
 
 			return model.Asset{}, err
@@ -87,8 +87,8 @@ func (a *assets) GetByID(ctx context.Context, id string) (model.Asset, error) {
 	return asset, nil
 }
 
-// enrichAssetWithURLs adds source, poster, and thumbnail URLs to the asset
-func (a *assets) enrichAssetWithURLs(playbackID string, policy muxgo.PlaybackPolicy, duration float64, asset *model.Asset) error {
+// hydrateAssetURLs adds source, poster, and thumbnail URLs to the asset
+func (a *assets) hydrateAssetURLs(playbackID string, policy muxgo.PlaybackPolicy, duration float64, asset *model.Asset) error {
 	var source, poster, thumbnail string
 	var err error
 

--- a/muxinc/muxinc.go
+++ b/muxinc/muxinc.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Assets struct
-type Assets struct {
+type assets struct {
 	logger    *logrus.Logger
 	mux       *muxgo.APIClient
 	keyID     string
@@ -26,8 +26,8 @@ func New(
 	l *logrus.Logger,
 	m *muxgo.APIClient,
 	cfg Config,
-) *Assets {
-	return &Assets{
+) *assets {
+	return &assets{
 		logger:    l,
 		mux:       m,
 		keyID:     cfg.KeyID,


### PR DESCRIPTION
This pull request includes updates to logging practices, enhancements to the Mux asset handling logic, and minor adjustments to licensing information. The most significant changes involve replacing the `logrus.Fields` logging pattern with `WithError` for simplicity, refactoring the Mux asset handling to improve URL generation, and updating the copyright year.

### Logging improvements:
* Replaced `logrus.Fields` with `WithError` for error logging in `mongodb/videos.go` and `muxinc/assets.go` to simplify and standardize logging. [[1]](diffhunk://#diff-2f8b0a7d112210b5ac56a5f91d53af381f8e69422a80b85d3c71796f89f284d1L53-R52) [[2]](diffhunk://#diff-2f8b0a7d112210b5ac56a5f91d53af381f8e69422a80b85d3c71796f89f284d1L76-R71) [[3]](diffhunk://#diff-2f8b0a7d112210b5ac56a5f91d53af381f8e69422a80b85d3c71796f89f284d1L106-R98) [[4]](diffhunk://#diff-af5c720c6fa05ea1a9c2b4a72c89a4230f54800e3235b9ae73d64c589a3ad3efL43-R51) [[5]](diffhunk://#diff-af5c720c6fa05ea1a9c2b4a72c89a4230f54800e3235b9ae73d64c589a3ad3efL58-R66)

### Mux asset handling enhancements:
* Introduced constants for image dimensions and time values in `muxinc/assets.go` to improve readability and maintainability.
* Refactored Mux asset URL generation by adding `hydrateAssetURLs`, `generatePublicURLs`, and `generateSignedURLs` helper methods for better modularity and error handling.
* Updated the `assets` struct and related methods to use lowercase naming for consistency and encapsulation. [[1]](diffhunk://#diff-af5c720c6fa05ea1a9c2b4a72c89a4230f54800e3235b9ae73d64c589a3ad3efL158-R197) [[2]](diffhunk://#diff-38376badb71c5712db832143f2ae64c1d32fdb872a17433feab03fda6440b887L9-R9) [[3]](diffhunk://#diff-38376badb71c5712db832143f2ae64c1d32fdb872a17433feab03fda6440b887L29-R30)

### Licensing updates:
* Updated the copyright year in `LICENSE` and `README.md` to 2025. [[1]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L190-R190)

### Dependency cleanup:
* Removed unused `logrus` import from `mongodb/videos.go` and `muxinc/assets.go`. [[1]](diffhunk://#diff-2f8b0a7d112210b5ac56a5f91d53af381f8e69422a80b85d3c71796f89f284d1L8) [[2]](diffhunk://#diff-af5c720c6fa05ea1a9c2b4a72c89a4230f54800e3235b9ae73d64c589a3ad3efL11-R31)