### PR TITLE
Upgrade Go version to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.24", "1.25"]
+        go: ["1.25", "1.26"]
     name: Go ${{ matrix.go }} build
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
This pull request updates the Go build workflow configuration to use newer versions of both Go and the setup action.

Workflow configuration updates:

* Updated the Go version matrix in `.github/workflows/go.yml` to test against Go `1.25` and `1.26` instead of `1.24` and `1.25`.
* Changed the `actions/setup-go` action from version `v5` to `v6` for improved compatibility and features.