### PR TITLE
Upgrade Go version to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25", "1.26"]
+        go: ["1.26"]
     name: Go ${{ matrix.go }} build
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/javiertlopez/idlemux
 
-go 1.25
+go 1.26
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in `go.mod`
- Update CI matrix to test against Go 1.26

Closes #23

## Test plan
- [ ] CI pipeline passes with Go 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)